### PR TITLE
DNS-SD WinRT Integration

### DIFF
--- a/samples/RNWinRTTestApp/App.tsx
+++ b/samples/RNWinRTTestApp/App.tsx
@@ -166,7 +166,11 @@ const App = () => {
     const [scanStatus, setScanStatus] = useState('');
 
     const handleDiscoverDevices = async () => {
+        setScanStatus('Scan in progress...');
+
         const dnssdLookupHelper = DnssdLookupHelper.getInstance();
+
+        // Tests dnssdLookupHelper.startListeningForDevicesAsync:
 
         console.log("calling dnssdLookupHelper.startListeningForDevices()");
         await dnssdLookupHelper.startListeningForDevicesAsync((devices: IDnssdServiceInstance[]) => {
@@ -177,7 +181,8 @@ const App = () => {
             setDiscoveredDevices(devices);
         });
 
-        // setScanStatus('Scan in progress...');
+        // Test dnssdLookupHelper.findAllDevicesAsync:
+
         // console.log("calling dnssdLookupHelper.findAllDevicesAsync()");
 
         // const startTime = Date.now();  // Capture start time
@@ -194,7 +199,7 @@ const App = () => {
         // setScanStatus(`Scan completed in ${duration} seconds. Found ${numberOfDevices} device(s).`);
         // console.log(discoveredDevices);
         
-        // Populate the discoveredDevices state
+        // // Populate the discoveredDevices state
         // setDiscoveredDevices(discoveredDevices);
     }
     

--- a/samples/RNWinRTTestApp/App.tsx
+++ b/samples/RNWinRTTestApp/App.tsx
@@ -168,25 +168,34 @@ const App = () => {
     const handleDiscoverDevices = async () => {
         const dnssdLookupHelper = DnssdLookupHelper.getInstance();
 
-        setScanStatus('Scan in progress...');
-        console.log("calling dnssdLookupHelper.findAllDevicesAsync()");
+        console.log("calling dnssdLookupHelper.startListeningForDevices()");
+        await dnssdLookupHelper.startListeningForDevicesAsync((devices: IDnssdServiceInstance[]) => {
+            console.log("Discovered devices so far:");
+            devices.forEach(device => {
+                console.log(device);
+            });
+            setDiscoveredDevices(devices);
+        });
 
-        const startTime = Date.now();  // Capture start time
+        // setScanStatus('Scan in progress...');
+        // console.log("calling dnssdLookupHelper.findAllDevicesAsync()");
+
+        // const startTime = Date.now();  // Capture start time
     
-        let discoveredDevices : IDnssdServiceInstance[] = await dnssdLookupHelper.findAllDevicesAsync();
+        // let discoveredDevices : IDnssdServiceInstance[] = await dnssdLookupHelper.findAllDevicesAsync();
     
-        const endTime = Date.now();  // Capture end time
+        // const endTime = Date.now();  // Capture end time
     
-        const duration = (endTime - startTime) / 1000;  // Calculate duration in seconds
-        const numberOfDevices = discoveredDevices.length;
+        // const duration = (endTime - startTime) / 1000;  // Calculate duration in seconds
+        // const numberOfDevices = discoveredDevices.length;
     
-        console.log(`Scan completed in ${duration} seconds. Found ${numberOfDevices} device(s).`);
+        // console.log(`Scan completed in ${duration} seconds. Found ${numberOfDevices} device(s).`);
     
-        setScanStatus(`Scan completed in ${duration} seconds. Found ${numberOfDevices} device(s).`);
-        console.log(discoveredDevices);
+        // setScanStatus(`Scan completed in ${duration} seconds. Found ${numberOfDevices} device(s).`);
+        // console.log(discoveredDevices);
         
         // Populate the discoveredDevices state
-        setDiscoveredDevices(discoveredDevices);
+        // setDiscoveredDevices(discoveredDevices);
     }
     
 

--- a/samples/RNWinRTTestApp/DnssdHelpers.ts
+++ b/samples/RNWinRTTestApp/DnssdHelpers.ts
@@ -8,7 +8,6 @@ const DnssdServiceWatcher = Dnssd.DnssdServiceWatcher;
  * https://learn.microsoft.com/en-us/uwp/api/windows.networking.servicediscovery.dnssd.dnssdserviceinstance?view=winrt-22621
  */
 export interface IDnssdServiceInstance {
-
     /** Host name of discovered service. */
     hostName: string;
 

--- a/samples/RNWinRTTestApp/DnssdHelpers.ts
+++ b/samples/RNWinRTTestApp/DnssdHelpers.ts
@@ -91,7 +91,10 @@ export class DnssdLookupHelper {
 
     /**
      * Enumerates IDnssdServiceInstance implementing objects matching the query parameters.
-     * 
+     * @example
+     * const finder = DnssdLookupHelper.getInstance();
+     * let devices = await finder.findAllDevicesAsync();
+     * @example
      * @returns A Promise that resolves to an array of objects implementing IDnssdServiceInstance.
      */
     public async findAllDevicesAsync(): Promise<IDnssdServiceInstance[]> {
@@ -155,7 +158,3 @@ export class DnssdLookupHelper {
         return services;
     }
 }
-
-// To use it:
-// const finder = DnssdLookupHelper.getInstance();
-// finder.findAllDevicesAsync();

--- a/samples/RNWinRTTestApp/DnssdHelpers.ts
+++ b/samples/RNWinRTTestApp/DnssdHelpers.ts
@@ -1,0 +1,161 @@
+const Dnssd = Windows.Networking.ServiceDiscovery.Dnssd;
+const DnssdServiceWatcher = Dnssd.DnssdServiceWatcher;
+
+/**
+ * Encapsulates an instance of a service that uses DNS Service Discovery (DNS-SD).
+ * This interface is based on Windows.Networking.ServiceDiscovery.Dnssd.DnssdServiceInstance.
+ * 
+ * https://learn.microsoft.com/en-us/uwp/api/windows.networking.servicediscovery.dnssd.dnssdserviceinstance?view=winrt-22621
+ */
+export interface IDnssdServiceInstance {
+
+    /** Host name of discovered service. */
+    hostName: string;
+
+    /** Service type portion of DNS-SD service instance name. (e.g. "_ipp._tcp" in "myservice._ipp._tcp.local") */
+    serviceName: string;
+
+    /** Instance portion of DNS-SD service instance name.(e.g. "myservice" in "myservice._ipp._tcp.local") */
+    instanceName: string;
+
+    /**
+     * An array of IP addresses associated with discovered service.
+     * Note: 
+     * - 0th item is IPv4 address.
+     * - 1st item is IPv6 address.
+     */
+    ipAddresses: string[];
+
+    /** IPv4 address of discovered service. Corresponds to 0th item of `ipAddresses` array. */
+    ipv4Address: string;
+
+    /** IPv6 address of discovered service. Corresponds to 1st item of `ipAddresses` array. */
+    ipv6Address: string;
+
+    /** Port number on which service is listening. */
+    portNumber: number;
+
+    /** Text data associated with the service instance. Each string is typically a key-value pair, separated by "=". */
+    textAttributes: string;
+}
+
+/**
+ * Helper class for looking up devices using the DNS-SD protocol.
+ * The class is implemented as a singleton, ensuring only one instance is created.
+ * 
+ * @remarks
+ * This helper focuses on devices that adhere to specific query parameters defined internally. If needed, this can easily be made more generic.
+ */
+export class DnssdLookupHelper {
+    private static instance: DnssdLookupHelper;
+
+    // Used to construct AQS query
+    // For specifics, refer https://learn.microsoft.com/en-us/windows/uwp/devices-sensors/enumerate-devices-over-a-network.
+    private static readonly PROTOCOL_GUID = "{4526e8c1-8aac-4153-9b16-55e86ada0e54}"; // Protocol type for DNS-SD.
+    private static readonly DOMAIN = "local";
+    private static readonly SERVICE_NAME = "_ssh._tcp";
+    // private static readonly SERVICE_NAME = "_ipp._tcp";
+
+    // Used to construct an iterable list of properties to look for in the devices that are discovered.
+    private static readonly HOSTNAME_PROPERTY = "System.Devices.Dnssd.HostName";
+    private static readonly SERVICENAME_PROPERTY = "System.Devices.Dnssd.ServiceName";
+    private static readonly INSTANCENAME_PROPERTY = "System.Devices.Dnssd.InstanceName";
+    private static readonly IPADDRESS_PROPERTY = "System.Devices.IpAddress";
+    private static readonly PORTNUMBER_PROPERTY = "System.Devices.Dnssd.PortNumber";
+    private static readonly TEXTATTRIBUTES_PROPERTY = "System.Devices.Dnssd.TextAttributes";
+
+    // TO DO: Support changing propertyKeys from consumer-side if needed.
+    private propertyKeys = [
+        DnssdLookupHelper.HOSTNAME_PROPERTY,
+        DnssdLookupHelper.SERVICENAME_PROPERTY,
+        DnssdLookupHelper.INSTANCENAME_PROPERTY,
+        DnssdLookupHelper.IPADDRESS_PROPERTY,
+        DnssdLookupHelper.PORTNUMBER_PROPERTY,
+        DnssdLookupHelper.TEXTATTRIBUTES_PROPERTY
+    ];
+
+    private constructor() { } // Private constructor ensures no external instantiation
+
+    /**
+     * Gets the singleton instance of `DnssdLookupHelper`.
+     * If no instance exists, it initializes a new one.
+     * 
+     * @returns The singleton instance of the `DnssdLookupHelper` class.
+     */
+    public static getInstance(): DnssdLookupHelper {
+        if (!DnssdLookupHelper.instance) {
+            DnssdLookupHelper.instance = new DnssdLookupHelper();
+        }
+        return DnssdLookupHelper.instance;
+    }
+
+    /**
+     * Enumerates IDnssdServiceInstance implementing objects matching the query parameters.
+     * 
+     * @returns A Promise that resolves to an array of objects implementing IDnssdServiceInstance.
+     */
+    public async findAllDevicesAsync(): Promise<IDnssdServiceInstance[]> {
+        const services: IDnssdServiceInstance[] = [];
+    
+        try {
+            const query = `System.Devices.AepService.ProtocolId:=${DnssdLookupHelper.PROTOCOL_GUID} AND System.Devices.Dnssd.Domain:=${DnssdLookupHelper.DOMAIN} AND System.Devices.Dnssd.ServiceName:=${DnssdLookupHelper.SERVICE_NAME}`;
+    
+            // NOTE: Casting `propertyKeys` to `unknown` first, and then to `Windows.Foundation.Collections.IIterable<string>`
+            // is a workaround to bypass type-related errors thrown by VS Code and in the runtime.
+            const devices = await Windows.Devices.Enumeration.DeviceInformation.findAllAsync(
+                query,
+                (this.propertyKeys as unknown as Windows.Foundation.Collections.IIterable<string>),
+                Windows.Devices.Enumeration.DeviceInformationKind.associationEndpointService
+            );
+    
+            for (let i = 0; i < devices.size; i++) {
+                const device = devices.getAt(i);
+                const properties = device.properties;
+                const serviceInfo: Partial<IDnssdServiceInstance> = {};
+    
+                this.propertyKeys.forEach((key: string) => {
+                    if (properties.hasKey(key)) {
+                        const value = properties.lookup(key);
+                        switch (key) {
+                            case DnssdLookupHelper.HOSTNAME_PROPERTY:
+                                serviceInfo.hostName = value;
+                                break;
+                            case DnssdLookupHelper.SERVICENAME_PROPERTY:
+                                serviceInfo.serviceName = value;
+                                break;
+                            case DnssdLookupHelper.INSTANCENAME_PROPERTY:
+                                serviceInfo.instanceName = value;
+                                break;
+                            case DnssdLookupHelper.IPADDRESS_PROPERTY:
+                                serviceInfo.ipAddresses = value as string[];
+                                if (serviceInfo.ipAddresses.length > 0) {
+                                    serviceInfo.ipv4Address = serviceInfo.ipAddresses[0];
+                                }
+                                if (serviceInfo.ipAddresses.length > 1) {
+                                    serviceInfo.ipv6Address = serviceInfo.ipAddresses[1];
+                                }
+                                break;
+                            case DnssdLookupHelper.PORTNUMBER_PROPERTY:
+                                serviceInfo.portNumber = value;
+                                break;
+                            case DnssdLookupHelper.TEXTATTRIBUTES_PROPERTY:
+                                serviceInfo.textAttributes = value;
+                                break;
+                        }
+                    }
+                });
+
+                services.push(serviceInfo as IDnssdServiceInstance);
+            }
+            console.log(`Found ${services.length} service(s)`);
+        } catch (error) {
+            console.error("Error discovering devices:", error);
+        }
+    
+        return services;
+    }
+}
+
+// To use it:
+// const finder = DnssdLookupHelper.getInstance();
+// finder.findAllDevicesAsync();

--- a/samples/RNWinRTTestApp/DnssdHelpers.ts
+++ b/samples/RNWinRTTestApp/DnssdHelpers.ts
@@ -129,14 +129,29 @@ export class DnssdLookupHelper {
                                 serviceInfo.instanceName = value;
                                 break;
                             case DnssdLookupHelper.IPADDRESS_PROPERTY:
-                                serviceInfo.ipAddresses = value as string[];
-                                if (serviceInfo.ipAddresses.length > 0) {
-                                    serviceInfo.ipv4Address = serviceInfo.ipAddresses[0];
+                            let ipAddressesArray = value as string[];
+                            serviceInfo.ipAddresses = ipAddressesArray;
+                            
+                            // Handles cases where:
+                            // 1. Both ipv4 and ipv6 addresses are present
+                            // 2. Only an ipv6 address is present
+                            if (ipAddressesArray.length > 0) {
+                                // Regex to check if an IP address is IPv4
+                                const ipv4Pattern = /^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}$/;
+
+                                if (ipv4Pattern.test(ipAddressesArray[0])) {
+                                    serviceInfo.ipv4Address = ipAddressesArray[0];
+                                } else {
+                                    serviceInfo.ipv6Address = ipAddressesArray[0];
                                 }
-                                if (serviceInfo.ipAddresses.length > 1) {
-                                    serviceInfo.ipv6Address = serviceInfo.ipAddresses[1];
-                                }
-                                break;
+                            }
+
+                            // Handles cases where both ipv4 and ipv6 addresses are present
+                            if (ipAddressesArray.length > 1) {
+                                // If two addresses are present, assume the second is always IPv6
+                                serviceInfo.ipv6Address = ipAddressesArray[1];
+                            }
+                            break;
                             case DnssdLookupHelper.PORTNUMBER_PROPERTY:
                                 serviceInfo.portNumber = value;
                                 break;

--- a/samples/RNWinRTTestApp/DnssdHelpers.ts
+++ b/samples/RNWinRTTestApp/DnssdHelpers.ts
@@ -79,7 +79,8 @@ export class DnssdLookupHelper {
     /**
      * Gets the singleton instance of `DnssdLookupHelper`.
      * If no instance exists, it initializes a new one.
-     * 
+     * @example
+     * const finder = DnssdLookupHelper.getInstance();
      * @returns The singleton instance of the `DnssdLookupHelper` class.
      */
     public static getInstance(): DnssdLookupHelper {
@@ -94,7 +95,6 @@ export class DnssdLookupHelper {
      * @example
      * const finder = DnssdLookupHelper.getInstance();
      * let devices = await finder.findAllDevicesAsync();
-     * @example
      * @returns A Promise that resolves to an array of objects implementing IDnssdServiceInstance.
      */
     public async findAllDevicesAsync(): Promise<IDnssdServiceInstance[]> {

--- a/samples/RNWinRTTestApp/DnssdHelpers.ts
+++ b/samples/RNWinRTTestApp/DnssdHelpers.ts
@@ -128,6 +128,12 @@ export class DnssdLookupHelper {
         return services;
     }
 
+    /**
+     * Extracts device properties from the given IMapView object and constructs an IDnssdServiceInstance object.
+     *
+     * @param properties - An IMapView containing device properties.
+     * @returns A Partial<IDnssdServiceInstance> containing extracted device properties.
+     */
     private getDeviceFromProperties(properties: Windows.Foundation.Collections.IMapView<string, any>): Partial<IDnssdServiceInstance> {   
         let serviceInfo: Partial<IDnssdServiceInstance> = {};
     
@@ -147,8 +153,12 @@ export class DnssdLookupHelper {
                     case DnssdLookupHelper.IPADDRESS_PROPERTY:
                         let ipAddressesArray = value as string[];
                         serviceInfo.ipAddresses = ipAddressesArray;
-    
+
+                        // Handles cases where:
+                        // 1. Both ipv4 and ipv6 addresses are present
+                        // 2. Only an ipv6 address is present
                         if (ipAddressesArray.length > 0) {
+                            // Regex to check if an IP address is IPv4
                             const ipv4Pattern = /^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}$/;
     
                             if (ipv4Pattern.test(ipAddressesArray[0])) {
@@ -158,7 +168,9 @@ export class DnssdLookupHelper {
                             }
                         }
     
+                        // Handles cases where both ipv4 and ipv6 addresses are present
                         if (ipAddressesArray.length > 1) {
+                            // If two addresses are present, assume the second is always IPv6
                             serviceInfo.ipv6Address = ipAddressesArray[1];
                         }
                         break;

--- a/samples/RNWinRTTestApp/DnssdHelpers.ts
+++ b/samples/RNWinRTTestApp/DnssdHelpers.ts
@@ -99,8 +99,7 @@ export class DnssdLookupHelper {
     }
 
     /**
-     * Enumerates IDnssdServiceInstance implement
-     * ing objects matching the query parameters.
+     * Enumerates IDnssdServiceInstance implementing objects matching the query parameters.
      * @example
      * const finder = DnssdLookupHelper.getInstance();
      * let devices = await finder.findAllDevicesAsync();

--- a/samples/RNWinRTTestApp/DnssdHelpers.ts
+++ b/samples/RNWinRTTestApp/DnssdHelpers.ts
@@ -130,10 +130,6 @@ export class DnssdLookupHelper {
 
     /**
      * A map that holds unique devices discovered by the device watcher during its listening sessions.
-     * 
-     * This map serves as the primary storage for devices that are detected in two primary scenarios:
-     * 1. During the initial scan executed when the watcher is started.
-     * 2. When new devices are discovered after the initial scan, as the watcher continues to monitor.
      * The contents of this map are cleared when the watcher is stopped, ensuring it remains fresh for each listening session.
      */
     private discoveredDevicesMap: { [id: string]: IDnssdServiceInstance } = {};
@@ -205,21 +201,11 @@ export class DnssdLookupHelper {
 
     /**
      * Stops the device watcher from listening for new devices.
-     * 
-     * This method is responsible for halting the device watcher, if it's currently active. Once stopped, the watcher will no longer detect or react to any changes in the devices available in the network. As a cleanup measure, upon successful stopping, the `discoveredDevicesMap` will be cleared to reset the state for future listening sessions.
-     * 
      * @remarks
      * If the watcher was not previously started, or is already stopped, this method will return `false`. On successful stopping, the method returns `true`.
-     * 
      * @example
      * // Stopping the device watcher:
      * const wasStopped = finder.stopListeningForDevices();
-     * if (wasStopped) {
-     *     console.log("Device watcher successfully stopped.");
-     * } else {
-     *     console.log("Device watcher was not active.");
-     * }
-     * 
      * @returns A boolean indicating whether the watcher was successfully stopped (`true`) or not (`false`).
      */
     public stopListeningForDevices(): boolean {

--- a/samples/RNWinRTTestApp/package.json
+++ b/samples/RNWinRTTestApp/package.json
@@ -11,6 +11,7 @@
     "windows": "react-native run-windows"
   },
   "dependencies": {
+    "ping": "^0.4.4",
     "react": "18.1.0",
     "react-native": "0.71.0",
     "react-native-windows": "0.71.0",
@@ -29,10 +30,10 @@
     "babel-jest": "^26.6.3",
     "eslint": "^7.32.0",
     "jest": "^26.6.3",
+    "metro-config": "^0.72.3",
     "metro-react-native-babel-preset": "^0.72.1",
     "react-test-renderer": "18.1.0",
-    "typescript": "^4.8.3",
-    "metro-config": "^0.72.3"
+    "typescript": "^4.8.3"
   },
   "jest": {
     "preset": "react-native",

--- a/samples/RNWinRTTestApp/windows/ExperimentalFeatures.props
+++ b/samples/RNWinRTTestApp/windows/ExperimentalFeatures.props
@@ -46,8 +46,11 @@
       -include Windows.Security.Cryptography.BinaryStringEncoding
       -include Windows.UI.Notifications
       -include Windows.Data.Xml.Dom
+      -include Windows.Networking.ServiceDiscovery.Dnssd
+      -include Windows.Devices.Enumeration
+      -include System.Devices.AepService
+          <!-- TO DO: Remove AepService if not needed -->
     </RnWinRTParameters>
-
   </PropertyGroup>
 
 </Project>

--- a/samples/RNWinRTTestApp/yarn.lock
+++ b/samples/RNWinRTTestApp/yarn.lock
@@ -6736,6 +6736,11 @@ pify@^4.0.1:
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
 
+ping@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/ping/-/ping-0.4.4.tgz#f70c5c8ad7b476d903100c9d45ecd52cf83e1de3"
+  integrity sha512-56ZMC0j7SCsMMLdOoUg12VZCfj/+ZO+yfOSjaNCRrmZZr6GLbN2X/Ui56T15dI8NhiHckaw5X2pvyfAomanwqQ==
+
 pirates@^4.0.1, pirates@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.5.tgz#feec352ea5c3268fb23a37c702ab1699f35a5f3b"


### PR DESCRIPTION
Introduces and adds the `DnssdHelper` module. Example usage in the `App.tsx` file.

Changelog:
- Addressed scenarios where only the IPv6 address is returned.
- Standardized and improved code formatting.
- Updated usage examples.
- Added logic to discover and render dnssd services in `App.tsx`.
- Integrated required includes for dnssd lookup.
- Implemented IDnssdServicelnstance interface and introduced the DnssdLookupHelper class.